### PR TITLE
Remove aria-controls

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -29,6 +29,15 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "oliverjam",
+      "name": "Oliver",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/9408641?v=4",
+      "profile": "http://www.oliverjam.es",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![version][version-badge]][package]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Chat][chat-badge]][chat]
 [![Code of Conduct][coc-badge]][coc]
@@ -194,8 +194,8 @@ are tons of them, so just
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/9488719?v=4" width="100px;"/><br /><sub>Frank Tan</sub>](https://github.com/tansongyang)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Code") [📖](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Documentation") [⚠️](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Tests") |
-| :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/9488719?v=4" width="100px;"/><br /><sub><b>Frank Tan</b></sub>](https://github.com/tansongyang)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Code") [📖](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Documentation") [⚠️](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Tests") | [<img src="https://avatars1.githubusercontent.com/u/9408641?v=4" width="100px;"/><br /><sub><b>Oliver</b></sub>](http://www.oliverjam.es)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=oliverjam "Code") |
+| :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -2,7 +2,6 @@
 
 exports[`getTogglerProps for \`on\` false 1`] = `
 Object {
-  "aria-controls": "target",
   "aria-expanded": false,
   "id": "extra",
   "onClick": [Function],
@@ -12,7 +11,6 @@ Object {
 
 exports[`getTogglerProps for \`on\` true 1`] = `
 Object {
-  "aria-controls": "target",
   "aria-expanded": true,
   "id": "extra",
   "onClick": [Function],

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,6 @@ class Toggle extends Component {
   }
 
   getTogglerProps = (props = {}) => ({
-    'aria-controls': 'target',
     'aria-expanded': Boolean(this.getOn()),
     tabIndex: 0,
     ...props,


### PR DESCRIPTION
**What**:
Remove `aria-controls` from the `getTogglerProps` method.

**Why**:
`aria-controls` only work in JAWS, and aren't particularly useful anyway (see ["aria-controls is poop"](http://www.heydonworks.com/article/aria-controls-is-poop). It's better to let users of the library choose to apply this attribute manually if they have a need for it. Relates #9 

**How**:
I removed the attribute from the props object returned by `getTogglerProps`, then updated the snapshots.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
