### PR TITLE
Call given onClick when using getInputTogglerProps(props) & getElemen…

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -79,6 +79,28 @@ test('getTogglerProps returns an onClick that calls the given onClick', () => {
   expect(childSpy).toHaveBeenLastCalledWith(expect.objectContaining({on: true}))
 })
 
+test('getElementTogglerProps returns an onClick that calls the given onClick', () => {
+  const {childSpy, getElementTogglerProps} = setup()
+  const mockClick = jest.fn()
+  const {onClick} = getElementTogglerProps({onClick: mockClick})
+  const fakeEvent = {target: null}
+  onClick(fakeEvent)
+  expect(mockClick).toHaveBeenCalledTimes(1)
+  expect(mockClick).toHaveBeenCalledWith(fakeEvent)
+  expect(childSpy).toHaveBeenLastCalledWith(expect.objectContaining({on: true}))
+})
+
+test('getInputTogglerProps returns an onClick that calls the given onClick', () => {
+  const {childSpy, getInputTogglerProps} = setup()
+  const mockClick = jest.fn()
+  const {onClick} = getInputTogglerProps({onClick: mockClick})
+  const fakeEvent = {target: null}
+  onClick(fakeEvent)
+  expect(mockClick).toHaveBeenCalledTimes(1)
+  expect(mockClick).toHaveBeenCalledWith(fakeEvent)
+  expect(childSpy).toHaveBeenLastCalledWith(expect.objectContaining({on: true}))
+})
+
 test('getElementTogglerProps returns an onKeyUp that toggles on enter', () => {
   const {childSpy, getElementTogglerProps} = setup()
   const {onKeyUp} = getElementTogglerProps()

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ class Toggle extends Component {
 
   getInputTogglerProps = (props = {}) =>
     this.getTogglerProps({
+      ...props,
       onKeyUp: callAll(props.onKeyUp, event => {
         if (event.key === 'Enter') {
           // <input> already respond to Enter
@@ -47,6 +48,7 @@ class Toggle extends Component {
 
   getElementTogglerProps = (props = {}) =>
     this.getTogglerProps({
+      ...props,
       onKeyUp: callAll(props.onKeyUp, event => {
         if (this.toggleKeys.indexOf(event.key) > -1) {
           this.toggle()


### PR DESCRIPTION

**What**:
Call given onClick when using getInputTogglerProps(props) & getElementTogglerProps(props)

**Why**:
This is a "bug fix" - if a click on both of those is supposed to call toggle then it should also call props.onClick

**How**:
Simple fix, im spreading props in both of those, so `callAll` can handle it in `getTogglerProps`.

**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged


