### PR TITLE
Fixed onToggle in controlled prop scenario

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -153,6 +153,21 @@ test('children can be an array (for preact support)', () => {
   )
 })
 
+test('onToggle gets called in controlled prop scenario', () => {
+  const spy = jest.fn()
+  const {wrapper} = setup({on: false, onToggle: spy})
+  expect(spy).not.toHaveBeenCalled()
+  wrapper.setProps({on: true})
+  expect(spy).toHaveBeenCalled()
+})
+
+test('onToggle gets called with fresh state in controlled prop scenario', () => {
+  const spy = jest.fn()
+  const {wrapper} = setup({on: false, onToggle: spy})
+  wrapper.setProps({on: true})
+  expect(spy).toHaveBeenLastCalledWith(true, expect.anything())
+})
+
 function setup({children = () => <div />, ...props} = {}) {
   let renderArg
   const childSpy = jest.fn(controllerArg => {

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,8 @@ class Toggle extends Component {
     on: this.getOn({on: this.props.defaultOn}),
   }
 
-  getOn(state = this.state) {
-    return this.isOnControlled() ? this.props.on : state.on
+  getOn(state = this.state, props = this.props) {
+    return this.isOnControlled() ? props.on : state.on
   }
 
   isOnControlled() {
@@ -69,18 +69,20 @@ class Toggle extends Component {
   }
 
   setOnState = (state = !this.getOn()) => {
-    if (this.isOnControlled()) {
-      this.props.onToggle(state, this.getTogglerStateAndHelpers())
-    } else {
-      this.setState({on: state}, () => {
-        this.props.onToggle(this.getOn(), this.getTogglerStateAndHelpers())
-      })
-    }
+    this.setState({on: state})
   }
 
   setOn = this.setOnState.bind(this, true)
   setOff = this.setOnState.bind(this, false)
   toggle = this.setOnState.bind(this, undefined)
+
+  componentDidUpdate(prevProps, prevState) {
+    const on = this.getOn()
+
+    if (this.getOn(prevState, prevProps) !== on) {
+      this.props.onToggle(on, this.getTogglerStateAndHelpers())
+    }
+  }
 
   render() {
     const renderProp = unwrapArray(this.props.children)


### PR DESCRIPTION
**What**:

fixes #16 
- `onToggle` was not called at all when controlled prop got updated i.e. based on redux state
- `onToggle` was actually called with stale value when updated with togglerProps (in controlled prop scenario)

<!-- Why are these changes necessary? -->
**Why**:
bug fix

<!-- How were these changes implemented? -->
**How**:
- I've unified controlled/uncontrolled prop scenarios and handle them the same in regards of `onToggle` in `componentDidUpdate`
- controlled prop use `setState` to trigger an update

**Checklist**:

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

After a thought this is not ideal - it works, but need extra render. The problem is that external data source needs to be notified about the change triggered through `togglerProps`, so we need to call `onToggle` to notify it, so we need to call it BEFORE the external state change (I've tricked the implementation to call it AFTER internal state change).

But we also need to call it AFTER external state change if the update comes from external state. Differentiating those 2 is clunky :s 

WDYT? do u have any ideas how this could be handled gracefully?
