### PR TITLE
Ensure onToggle is called when on is controlled but setOnState is called

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -47,6 +47,16 @@
       "contributions": [
         "code"
       ]
-    }
+    },
+    {
+          "login": "bslinger",
+          "name": "Ben Slinger",
+          "avatar_url": "https://avatars1.githubusercontent.com/u/603386?v=4",
+          "profile": "https://github.com/bslinger",
+          "contributions": [
+            "code",
+            "test"
+          ]
+        }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![version][version-badge]][package]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Chat][chat-badge]][chat]
 [![Code of Conduct][coc-badge]][coc]
@@ -196,11 +196,9 @@ are tons of them, so just
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-
 <!-- prettier-ignore -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/9488719?v=4" width="100px;"/><br /><sub><b>Frank Tan</b></sub>](https://github.com/tansongyang)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Code") [📖](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Documentation") [⚠️](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Tests") | [<img src="https://avatars1.githubusercontent.com/u/9408641?v=4" width="100px;"/><br /><sub><b>Oliver</b></sub>](http://www.oliverjam.es)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=oliverjam "Code") | [<img src="https://avatars2.githubusercontent.com/u/11708648?v=4" width="100px;"/><br /><sub><b>Jedrzej Lewandowski</b></sub>](http://www.thefullresolution.com/)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=TheFullResolution "Code") |
-| :---: | :---: | :---: | :---: |
-
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/react-toggled/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/9488719?v=4" width="100px;"/><br /><sub><b>Frank Tan</b></sub>](https://github.com/tansongyang)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Code") [📖](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Documentation") [⚠️](https://github.com/kentcdodds/react-toggled/commits?author=tansongyang "Tests") | [<img src="https://avatars1.githubusercontent.com/u/9408641?v=4" width="100px;"/><br /><sub><b>Oliver</b></sub>](http://www.oliverjam.es)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=oliverjam "Code") | [<img src="https://avatars2.githubusercontent.com/u/11708648?v=4" width="100px;"/><br /><sub><b>Jedrzej Lewandowski</b></sub>](http://www.thefullresolution.com/)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=TheFullResolution "Code") | [<img src="https://avatars1.githubusercontent.com/u/603386?v=4" width="100px;"/><br /><sub><b>Ben Slinger</b></sub>](https://github.com/bslinger)<br />[💻](https://github.com/kentcdodds/react-toggled/commits?author=bslinger "Code") [⚠️](https://github.com/kentcdodds/react-toggled/commits?author=bslinger "Tests") |
+| :---: | :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -172,10 +172,10 @@ test('onToggle gets called with fresh state in controlled prop scenario', () => 
 
 test('onToggle gets called when setOnState is called in controlled prop scenario', () => {
   const spy = jest.fn()
-  const {getTogglerProps} = setup({on: false, onToggle: spy})
-  const {onClick} = getTogglerProps()
-  const fakeEvent = {target: null}
-  onClick(fakeEvent)
+  const {setOn, setOff} = setup({on: false, onToggle: spy})
+  setOff()
+  expect(spy).not.toHaveBeenCalled()
+  setOn()
   expect(spy).toHaveBeenLastCalledWith(true, expect.anything())
   expect(spy.mock.calls.length).toBe(1)
 })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -159,6 +159,7 @@ test('onToggle gets called in controlled prop scenario', () => {
   expect(spy).not.toHaveBeenCalled()
   wrapper.setProps({on: true})
   expect(spy).toHaveBeenCalled()
+  expect(spy.mock.calls.length).toBe(1)
 })
 
 test('onToggle gets called with fresh state in controlled prop scenario', () => {
@@ -166,6 +167,17 @@ test('onToggle gets called with fresh state in controlled prop scenario', () => 
   const {wrapper} = setup({on: false, onToggle: spy})
   wrapper.setProps({on: true})
   expect(spy).toHaveBeenLastCalledWith(true, expect.anything())
+  expect(spy.mock.calls.length).toBe(1)
+})
+
+test('onToggle gets called when setOnState is called in controlled prop scenario', () => {
+  const spy = jest.fn()
+  const {getTogglerProps} = setup({on: false, onToggle: spy})
+  const {onClick} = getTogglerProps()
+  const fakeEvent = {target: null}
+  onClick(fakeEvent)
+  expect(spy).toHaveBeenLastCalledWith(true, expect.anything())
+  expect(spy.mock.calls.length).toBe(1)
 })
 
 function setup({children = () => <div />, ...props} = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,9 @@ class Toggle extends Component {
   }
 
   setOnState = (state = !this.getOn()) => {
+    if (this.getOn() !== state) {
+      this.props.onToggle(state, this.getTogglerStateAndHelpers())
+    }
     this.setState({on: state})
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Fix a bug introduced in #17 that prevents onToggle from being called when the internal setOnState is called.

<!-- Why are these changes necessary? -->
**Why**: When `on` is controlled, onToggle should be called either when the controlled prop is change, or when the internal toggle actually occurs

<!-- How were these changes implemented? -->
**How**: I added a check in setOnState to compare the current `on` with the new state and call `onToggle` if necessary.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
