### PR TITLE
Only fire onToggle on external props change if it's different to inte…

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -170,13 +170,14 @@ test('onToggle gets called with fresh state in controlled prop scenario', () => 
   expect(spy.mock.calls.length).toBe(1)
 })
 
-test('onToggle gets called when setOnState is called in controlled prop scenario', () => {
+test('onToggle gets called on internal state change in controlled prop scenario', () => {
   const spy = jest.fn()
-  const {setOn, setOff} = setup({on: false, onToggle: spy})
+  const {setOn, setOff, wrapper} = setup({on: false, onToggle: spy})
   setOff()
   expect(spy).not.toHaveBeenCalled()
   setOn()
   expect(spy).toHaveBeenLastCalledWith(true, expect.anything())
+  wrapper.setProps({on: true})
   expect(spy.mock.calls.length).toBe(1)
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -79,11 +79,9 @@ class Toggle extends Component {
   setOff = this.setOnState.bind(this, false)
   toggle = this.setOnState.bind(this, undefined)
 
-  componentDidUpdate(prevProps, prevState) {
-    const on = this.getOn()
-
-    if (this.getOn(prevState, prevProps) !== on) {
-      this.props.onToggle(on, this.getTogglerStateAndHelpers())
+  componentWillReceiveProps(newProps) {
+    if (newProps.on !== this.props.on && newProps.on !== this.state.on) {
+      this.setOnState(newProps.on)
     }
   }
 


### PR DESCRIPTION
…rnal on state to avoid double firing

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: My last change introduced a bug which makes onToggle fire twice when a controlled prop is updated via the internal setOnState and then that new prop is passed back in to the component

<!-- Why are these changes necessary? -->
**Why**: We want onToggle to only fire once for a change in state, whether it's triggered by an internal or external state change

<!-- How were these changes implemented? -->
**How**: Replaced componentDidUpdate with componentWillReceiveProps to check for a change in props, and only fire onToggle if the current internal state is different

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation - N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
