### PR TITLE
docs: remove CodeFund sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-<p align="center">
-<a href="https://codefund.io/properties/494/visit-sponsor">
-<img src="https://codefund.io/properties/494/sponsor" />
-</a>
-</p>
-
 <h1 align="center">
   react-toggled ⚛️
   <br>


### PR DESCRIPTION
**What**:

Remove CodeFund sponsor ad from the README

**Why**:

CodeFund is not allowed to place ads on README's anymore according to GitHub.
Please reach out to our team if you have any questions :slightly_smiling_face: 

**How**:

Remove code from the top of the README

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
